### PR TITLE
Render messages as Markdown

### DIFF
--- a/ChatBot.xcodeproj/project.pbxproj
+++ b/ChatBot.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		384356E829B2F353005F2DBF /* OpenAIServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 384356E729B2F353005F2DBF /* OpenAIServer.swift */; };
 		384356EA29B2F70C005F2DBF /* APIKeyConfigurator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 384356E929B2F70C005F2DBF /* APIKeyConfigurator.swift */; };
 		384356EF29B3940F005F2DBF /* ConditionalModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 384356EE29B3940F005F2DBF /* ConditionalModifier.swift */; };
+		FD79A32629BB48AF0045CDAC /* MarkdownUI in Frameworks */ = {isa = PBXBuildFile; productRef = FD79A32529BB48AF0045CDAC /* MarkdownUI */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -46,6 +47,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				FD79A32629BB48AF0045CDAC /* MarkdownUI in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -138,6 +140,9 @@
 			dependencies = (
 			);
 			name = ChatBot;
+			packageProductDependencies = (
+				FD79A32529BB48AF0045CDAC /* MarkdownUI */,
+			);
 			productName = ChatBot;
 			productReference = 3841FB3529B0A7DE00AAC814 /* ChatBot.app */;
 			productType = "com.apple.product-type.application";
@@ -166,6 +171,9 @@
 				Base,
 			);
 			mainGroup = 3841FB2C29B0A7DE00AAC814;
+			packageReferences = (
+				FD79A32429BB48AF0045CDAC /* XCRemoteSwiftPackageReference "swift-markdown-ui" */,
+			);
 			productRefGroup = 3841FB3629B0A7DE00AAC814 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -416,6 +424,25 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		FD79A32429BB48AF0045CDAC /* XCRemoteSwiftPackageReference "swift-markdown-ui" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/gonzalezreal/swift-markdown-ui";
+			requirement = {
+				kind = exactVersion;
+				version = 2.0.1;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		FD79A32529BB48AF0045CDAC /* MarkdownUI */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = FD79A32429BB48AF0045CDAC /* XCRemoteSwiftPackageReference "swift-markdown-ui" */;
+			productName = MarkdownUI;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 3841FB2D29B0A7DE00AAC814 /* Project object */;
 }

--- a/ChatBot/View/DialogView.swift
+++ b/ChatBot/View/DialogView.swift
@@ -5,6 +5,7 @@
 //  Created by LiYanan2004 on 2023/3/2.
 //
 
+import MarkdownUI
 import SwiftUI
 
 struct DialogView: View {
@@ -13,7 +14,7 @@ struct DialogView: View {
     
     var body: some View {
         VStack(spacing: 10) {
-            Text(verbatim: dialog.userMessage)
+            Markdown(dialog.userMessage)
                 .unlimitedText()
                 .padding()
                 .frame(maxWidth: .infinity, alignment: .trailing)
@@ -38,7 +39,7 @@ struct DialogView: View {
                                 }
                             }
                     } else {
-                        Text(verbatim: dialog.botMessage)
+                        Markdown(dialog.botMessage)
                             .unlimitedText()
                     }
                 }


### PR DESCRIPTION
In certain situations (e.g., a message includes source code), rendering messages as Markdown would be beneficial for their readability. This PR uses [MarkdownUI](https://github.com/gonzalezreal/swift-markdown-ui) to render Markdown as [`AttributedString`](https://developer.apple.com/documentation/foundation/attributedstring) poses issues with line breaks. The result looks as follows (the first image shows the current implementation):

![Raw Message Display](https://user-images.githubusercontent.com/13868083/224481596-14ad7e2d-632b-4124-a27c-0461ae5b847e.png)
![Markdown Message Display](https://user-images.githubusercontent.com/13868083/224481609-f283bf03-0e7d-4755-bffe-183b92b11b6e.png)
