### PR TITLE
Rename conversation in sidebar

### DIFF
--- a/ChatBot/Model/ChatBot.swift
+++ b/ChatBot/Model/ChatBot.swift
@@ -91,7 +91,7 @@ class ChatBot: ObservableObject {
         answer(dialogs[dialogs.count - 1].userMessage, retry: true)
     }
     
-    @MainActor private func setTitle(_ title: String, conversation: Conversation?) {
+    @MainActor func setTitle(_ title: String, conversation: Conversation?) {
         guard let conversation else { return }
         guard conversation.id == self.conversation?.id else {
             if let index = conversations.firstIndex(where: { $0.id == conversation.id }) {


### PR DESCRIPTION
The default titles generated for conversations are very lengthy. Sometimes, I would prefer to give a title to a conversation manually. Hence, this PR introduces the possibility to rename a conversation from the sidebar through the context menu:

https://user-images.githubusercontent.com/13868083/224481721-66f0a0b2-c9a5-4f9f-b5dd-8f3a51c014b4.mp4

_Note that this implementation only addresses macOS._