### PR TITLE
Allow multiline input

### DIFF
--- a/ChatBot/ContentView.swift
+++ b/ChatBot/ContentView.swift
@@ -61,6 +61,7 @@ struct ContentView: View {
                         .labelStyle(.iconOnly)
                         .bordedBackground()
                         .frame(width: 32)
+                        .keyboardShortcut(.return, modifiers: .command)
                     } else {
                         TextField("Type to ask ChatGPT", text: $text)
                             .textFieldStyle(.plain)

--- a/ChatBot/ContentView.swift
+++ b/ChatBot/ContentView.swift
@@ -39,14 +39,13 @@ struct ContentView: View {
             }
             .textSelection(.enabled)
             .safeAreaInset(edge: .bottom) {
-                HStack {
+                HStack(alignment: .bottom) {
                     if #available(macOS 13.0, iOS 16, *) {
                         TextEditor(text: $text)
                             .font(.body)
                             .scrollContentBackground(.hidden)
-                            .padding()
                             .foregroundColor(.primary)
-                            .frame(minHeight: 50, maxHeight: 150)
+                            .frame(maxHeight: 150)
                             .bordedBackground()
                         Button {
                             if canSendMessage {


### PR DESCRIPTION
Currently, the message input only allows for single-line input, even for messages pasted to the input. However, pasting or typing source code mostly requires multiple lines. Hence, this PR introduces the possibility to submit multiline messages on macOS and iOS:

https://user-images.githubusercontent.com/13868083/224481929-5e829ecb-a310-4020-8a3f-74b64ef22ddc.mp4